### PR TITLE
KSM-532: Added custom proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ secretsManager.Save(secretToUpdate)
 
 # Change Log
 
+## 1.7.0
+
+* KSM-532 - Add proxy support
+
 ## 1.6.4
 
 * KSM-551 - Stop generating UIDs that start with "-"

--- a/core/core.go
+++ b/core/core.go
@@ -155,12 +155,8 @@ func NewSecretsManager(options *ClientOptions, arg ...interface{}) *SecretsManag
 		sm.Config.Set(KEY_SERVER_PUBLIC_KEY_ID, defaultKeeperServerPublicKeyId)
 	}
 
-	envProxyUrl := os.Getenv("KSM_PROXY")
-
 	if options != nil && options.ProxyUrl != "" {
 		sm.ProxyUrl = options.ProxyUrl
-	} else if envProxyUrl != "" {
-		sm.ProxyUrl = envProxyUrl
 	}
 
 	if err := sm.init(); err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"regexp"
@@ -40,6 +41,9 @@ type ClientOptions struct {
 
 	// Deprecated: Use Token instead. If both are set, hostname from the token takes priority.
 	Hostname string
+
+	// ProxyUrl specifies the URL of the proxy to use
+	ProxyUrl string
 }
 
 type SecretsManager struct {
@@ -49,6 +53,7 @@ type SecretsManager struct {
 	Config         IKeyValueStorage
 	context        **Context
 	cache          ICache
+	ProxyUrl       string
 }
 
 // NewSecretsManager returns new *SecretsManager initialized with the options provided.
@@ -148,6 +153,14 @@ func NewSecretsManager(options *ClientOptions, arg ...interface{}) *SecretsManag
 	} else if _, found := keeperServerPublicKeys[pkid]; !found {
 		klog.Debug(fmt.Sprintf("Public key id %s does not exists, set to default: %s", pkid, defaultKeeperServerPublicKeyId))
 		sm.Config.Set(KEY_SERVER_PUBLIC_KEY_ID, defaultKeeperServerPublicKeyId)
+	}
+
+	envProxyUrl := os.Getenv("KSM_PROXY")
+
+	if options != nil && options.ProxyUrl != "" {
+		sm.ProxyUrl = options.ProxyUrl
+	} else if envProxyUrl != "" {
+		sm.ProxyUrl = envProxyUrl
 	}
 
 	if err := sm.init(); err != nil {
@@ -853,12 +866,7 @@ func (c *SecretsManager) PostFunction(
 	rq.Header.Set("Authorization", fmt.Sprintf("Signature %s", BytesToBase64(encryptedPayloadAndSignature.Signature)))
 	// klog.Debug(rq.Header)
 
-	tr := http.DefaultClient.Transport
-	if insecureSkipVerify := !verifySslCerts; insecureSkipVerify {
-		tr = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
-		}
-	}
+	tr := getTransport(c.ProxyUrl, verifySslCerts)
 	client := &http.Client{Transport: tr}
 
 	rs, err := client.Do(rq)
@@ -1368,12 +1376,7 @@ func (c *SecretsManager) fileUpload(url, parameters string, successStatusCode in
 
 	rq.Header.Set("Content-Type", w.FormDataContentType())
 
-	tr := http.DefaultClient.Transport
-	if insecureSkipVerify := !c.VerifySslCerts; insecureSkipVerify {
-		tr = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
-		}
-	}
+	tr := getTransport(c.ProxyUrl, c.VerifySslCerts)
 	client := &http.Client{Transport: tr}
 
 	rs, err := client.Do(rq)
@@ -2429,4 +2432,31 @@ func getRawFieldValue(field map[string]interface{}) []interface{} {
 	}
 
 	return nil
+}
+
+func getTransport(proxyUrl string, VerifySslCerts bool) *http.Transport {
+	var transport *http.Transport
+
+	// If proxyUrl is provided, parse it and set Proxy
+	if proxyUrl != "" {
+		proxyURL, err := url.Parse(proxyUrl)
+		if err != nil {
+			klog.Error(fmt.Sprintf("Error parsing proxy URL: %s", err.Error()))
+		}
+		transport = &http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+		}
+	} else {
+		transport = &http.Transport{}
+	}
+
+	// If VerifySslCerts is false, set TLSClientConfig to skip certificate verification
+	if !VerifySslCerts {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+
+	return transport
 }

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	ksm "github.com/keeper-security/secrets-manager-go/core"
+)
+
+func TestProxyUrlEnvVar(t *testing.T) {
+	// Save and defer restore of KSM_PROXY
+	origProxy := os.Getenv("KSM_PROXY")
+	defer os.Setenv("KSM_PROXY", origProxy)
+
+	testUrl := "http://localhost:8888"
+	os.Setenv("KSM_PROXY", testUrl)
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config})
+
+	if sm.ProxyUrl != testUrl {
+		t.Errorf("Expected ProxyUrl to be %s from KSM_PROXY env var, got %s", testUrl, sm.ProxyUrl)
+	}
+}
+
+func TestProxyUrlArgument(t *testing.T) {
+	proxyUrl := "http://myproxy:9999"
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config, ProxyUrl: proxyUrl})
+
+	if sm.ProxyUrl != proxyUrl {
+		t.Errorf("Expected ProxyUrl to be %s from argument, got %s", proxyUrl, sm.ProxyUrl)
+	}
+}
+
+func TestProxyUrlArgumentOverridesEnvVar(t *testing.T) {
+	// Save and defer restore of KSM_PROXY
+	origProxy := os.Getenv("KSM_PROXY")
+	defer os.Setenv("KSM_PROXY", origProxy)
+
+	envProxy := "http://envproxy:8080"
+	argProxy := "http://argproxy:9090"
+
+	os.Setenv("KSM_PROXY", envProxy)
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config, ProxyUrl: argProxy})
+
+	if sm.ProxyUrl != argProxy {
+		t.Errorf("Expected ProxyUrl to be %s (argument should override env), got %s", argProxy, sm.ProxyUrl)
+	}
+}
+
+func TestProxyUrlDefaultEmpty(t *testing.T) {
+	// Save and defer restore of KSM_PROXY
+	origProxy := os.Getenv("KSM_PROXY")
+	defer os.Setenv("KSM_PROXY", origProxy)
+
+	// Unset KSM_PROXY
+	os.Unsetenv("KSM_PROXY")
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+
+	// Do not pass ProxyUrl argument
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config})
+
+	if sm.ProxyUrl != "" {
+		t.Errorf("Expected ProxyUrl to be empty when neither env var nor argument is set, got %s", sm.ProxyUrl)
+	}
+}

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -7,24 +7,6 @@ import (
 	ksm "github.com/keeper-security/secrets-manager-go/core"
 )
 
-func TestProxyUrlEnvVar(t *testing.T) {
-	// Save and defer restore of KSM_PROXY
-	origProxy := os.Getenv("KSM_PROXY")
-	defer os.Setenv("KSM_PROXY", origProxy)
-
-	testUrl := "http://localhost:8888"
-	os.Setenv("KSM_PROXY", testUrl)
-
-	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
-	config := ksm.NewMemoryKeyValueStorage(configJson)
-
-	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config})
-
-	if sm.ProxyUrl != testUrl {
-		t.Errorf("Expected ProxyUrl to be %s from KSM_PROXY env var, got %s", testUrl, sm.ProxyUrl)
-	}
-}
-
 func TestProxyUrlArgument(t *testing.T) {
 	proxyUrl := "http://myproxy:9999"
 
@@ -38,34 +20,7 @@ func TestProxyUrlArgument(t *testing.T) {
 	}
 }
 
-func TestProxyUrlArgumentOverridesEnvVar(t *testing.T) {
-	// Save and defer restore of KSM_PROXY
-	origProxy := os.Getenv("KSM_PROXY")
-	defer os.Setenv("KSM_PROXY", origProxy)
-
-	envProxy := "http://envproxy:8080"
-	argProxy := "http://argproxy:9090"
-
-	os.Setenv("KSM_PROXY", envProxy)
-
-	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
-	config := ksm.NewMemoryKeyValueStorage(configJson)
-
-	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config, ProxyUrl: argProxy})
-
-	if sm.ProxyUrl != argProxy {
-		t.Errorf("Expected ProxyUrl to be %s (argument should override env), got %s", argProxy, sm.ProxyUrl)
-	}
-}
-
 func TestProxyUrlDefaultEmpty(t *testing.T) {
-	// Save and defer restore of KSM_PROXY
-	origProxy := os.Getenv("KSM_PROXY")
-	defer os.Setenv("KSM_PROXY", origProxy)
-
-	// Unset KSM_PROXY
-	os.Unsetenv("KSM_PROXY")
-
 	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
 	config := ksm.NewMemoryKeyValueStorage(configJson)
 


### PR DESCRIPTION
Go by default supports HTTPS_PROXY env var
Added support for passing ProxyUrl to ksm.ClientOptions