### PR TITLE
KSM-663 - Handle broken encryption in records, folders and files

### DIFF
--- a/core/dtos.go
+++ b/core/dtos.go
@@ -462,9 +462,20 @@ func NewRecordFromJson(recordDict map[string]interface{}, secretKey []byte, fold
 		if rfSlice, ok := recordFiles.([]interface{}); ok {
 			for i := range rfSlice {
 				if rfMap, ok := rfSlice[i].(map[string]interface{}); ok {
-					if file := NewKeeperFileFromJson(rfMap, record.RecordKeyBytes); file != nil {
-						record.Files = append(record.Files, file)
-					}
+					func() {
+						defer func() {
+							if err := recover(); err != nil {
+								if fileUid, ok := rfMap["fileUid"]; ok {
+									klog.Error(fmt.Sprintf("File %s skipped due to error: %v", fileUid, err))
+								} else {
+									klog.Error(fmt.Sprintf("File skipped due to error: %v", err))
+								}
+							}
+						}()
+						if file := NewKeeperFileFromJson(rfMap, record.RecordKeyBytes); file != nil {
+							record.Files = append(record.Files, file)
+						}
+					}()
 				}
 			}
 		}
@@ -1112,11 +1123,22 @@ func (f *Folder) Records() []*Record {
 	records := []*Record{}
 	if f.folderRecords != nil {
 		for _, r := range f.folderRecords {
-			if record := NewRecordFromJson(r, f.key, f.uid); record.Uid != "" {
-				records = append(records, record)
-			} else {
-				klog.Error("error parsing folder record: ", r)
-			}
+			func() {
+				defer func() {
+					if err := recover(); err != nil {
+						if uid, ok := r["recordUid"]; ok {
+							klog.Error(fmt.Sprintf("Record %s in folder %s skipped due to error: %v", uid, f.uid, err))
+						} else {
+							klog.Error(fmt.Sprintf("Record in folder %s skipped due to error: %v", f.uid, err))
+						}
+					}
+				}()
+				if record := NewRecordFromJson(r, f.key, f.uid); record != nil && record.Uid != "" {
+					records = append(records, record)
+				} else {
+					klog.Error("error parsing folder record: ", r)
+				}
+			}()
 		}
 	}
 	return records


### PR DESCRIPTION
Fixes #816

Add error handling to gracefully skip records, folders, and files with broken encryption instead of failing the entire request. This matches the Python SDK implementation from KSM-529.

- Use defer/recover pattern for error handling
- Log errors for skipped items
- Continue processing valid items
- Return partial results successfully