### PR TITLE
Fix file permissions for Go SDK config files

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -81,7 +81,8 @@ func (f *fileKeyValueStorage) SaveStorage(updatedConfig map[string]interface{}) 
 		klog.Error("Error writing JSON: " + err.Error())
 		return
 	}
-	if err := ioutil.WriteFile(f.ConfigPath, content, 0666); err != nil {
+	// Create file with secure permissions (0600) - owner read/write only
+	if err := ioutil.WriteFile(f.ConfigPath, content, 0600); err != nil {
 		klog.Error("Error writing JSON configuration file: " + err.Error())
 	}
 }
@@ -151,7 +152,8 @@ func (f *fileKeyValueStorage) createConfigFileIfMissing() {
 			klog.Error("Error creating folders: " + err.Error())
 		}
 
-		if c, err := os.Create(f.ConfigPath); err == nil {
+		// Create file with secure permissions (0600) - owner read/write only
+		if c, err := os.OpenFile(f.ConfigPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600); err == nil {
 			defer c.Close()
 			if _, err := c.WriteString("{}"); err != nil {
 				klog.Error("Failed to write config content: " + err.Error())

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,2 +1,4 @@
 github.com/keeper-security/secrets-manager-go/core v1.6.3 h1:XEHZ8fQ2DFBISK80jWdHmzT56PFqEkXSkakqZxTD8zI=
 github.com/keeper-security/secrets-manager-go/core v1.6.3/go.mod h1:dtlaeeds9+SZsbDAZnQRsDSqEAK9a62SYtqhNql+VgQ=
+github.com/keeper-security/secrets-manager-go/core v1.6.4 h1:ly2XvAgDxHoHVvFXOIYlxzxBF0yoQir1KfNHUNG4eRA=
+github.com/keeper-security/secrets-manager-go/core v1.6.4/go.mod h1:dtlaeeds9+SZsbDAZnQRsDSqEAK9a62SYtqhNql+VgQ=


### PR DESCRIPTION
  Jira: https://keeper.atlassian.net/browse/KSM-701

  Problem

  The Go SDK created configuration files (client-config.json) with insecure permissions that exposed sensitive credentials to all users on the system:

  - SaveStorage() explicitly used mode 0666 (world-readable and world-writable)
  - createConfigFileIfMissing() used os.Create() which defaults to mode 0666

  Changes

  File: core/storage.go

  1. Line 85 - SaveStorage():
    - Changed ioutil.WriteFile() mode from 0666 to 0600
  2. Line 156 - createConfigFileIfMissing():
    - Replaced os.Create() (uses 0666) with os.OpenFile()
    - Added explicit flags: os.O_WRONLY | os.O_CREATE | os.O_TRUNC
    - Set mode to 0600

  Security Impact

  Before: 0666 = rw-rw-rw- (world-readable and world-writable)
  After: 0600 = rw------- (owner read/write only)

  Config files now created with owner-only permissions, preventing unauthorized access to sensitive credentials (privateKey, appKey, clientId).

  Testing

  - Ran full test suite: cd test && go test -p 1 ./...
  - Core functionality tests pass
  - 3 test failures are pre-existing and unrelated (caused by KSM_CONFIG environment variable in test environment)