### PR TITLE
KSM-745: add transmission public key #18 for Gov Cloud Dev support

### DIFF
--- a/core/keeper_globals.go
+++ b/core/keeper_globals.go
@@ -65,5 +65,6 @@ var (
 		"15": "BDKyWBvLbyZ-jMueORl3JwJnnEpCiZdN7yUvT0vOyjwpPBCDf6zfL4RWzvSkhAAFnwOni_1tQSl8dfXHbXqXsQ8",
 		"16": "BDXyZZnrl0tc2jdC5I61JjwkjK2kr7uet9tZjt8StTiJTAQQmnVOYBgbtP08PWDbecxnHghx3kJ8QXq1XE68y8c",
 		"17": "BFX68cb97m9_sweGdOVavFM3j5ot6gveg6xT4BtGahfGhKib-zdZyO9pwvv1cBda9ahkSzo1BQ4NVXp9qRyqVGU",
+		"18": "BNhngQqTT1bPKxGuB6FhbPTAeNVFl8PKGGSGo5W06xWIReutm6ix6JPivqnbvkydY-1uDQTr-5e6t70G01Bb5JA",
 	}
 )


### PR DESCRIPTION
## Summary

Adds transmission public key #18 to enable Go SDK connectivity to Gov Cloud Dev environment.

## Changes

• Added public key #18 to keeper_globals.go keeperServerPublicKeys map (line 68)

## Technical Details

Gov Cloud Dev environment ( govcloud.dev.keepersecurity.us ) is configured with transmission public key ID 18. The SDK previously only supported keys 7-17, causing connection failures with error "Key number 18 is not supported".