### PR TITLE
Add placeholder for publish workflow

### DIFF
--- a/.github/workflows/publish.go.yml
+++ b/.github/workflows/publish.go.yml
@@ -1,0 +1,24 @@
+name: Publish Go SDK to pkg.go.dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish release (uncheck to build/test only)'
+        required: false
+        default: 'true'
+        type: boolean
+      version_tag:
+        description: 'Version tag (e.g., v1.7.0, leave empty to auto-detect)'
+        required: false
+        type: string
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "This is a placeholder workflow on master branch."
+          echo "The full implementation exists on release branches."
+          echo "Run this workflow from a release branch to publish."


### PR DESCRIPTION
Adds minimal publish.go.yml workflow file to master branch.

This placeholder allows the full workflow implementation (on release branches) to be discoverable and runnable by GitHub Actions.

The actual publish workflow logic exists on release branches where it can be version-specific.