### PR TITLE
KSM-911: skip records whose AES-GCM data decryption fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ func main() {
 	// sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: ksm.NewFileKeyValueStorage("ksm-config.json")})
 
 	// Retrieve all records
-	allRecords, _ := sm.GetSecrets([]string{})
+	allRecords, err := sm.GetSecrets([]string{})
+	if err != nil || len(allRecords) == 0 {
+		print("No records found")
+		return
+	}
 
 	// Get password from first record:
 	password := allRecords[0].Password()
@@ -185,12 +189,17 @@ See [`example/custom-cache/`](example/custom-cache/) for a complete working impl
 * KSM-616 - Remove deprecated ioutil dependency
 * KSM-626 - Add GraphSync links
 * KSM-632 - Add links2Remove parameter for files removal
+* KSM-658 - Add custom cache example and document ICache interface
 * KSM-663 - Handle broken records, files, and folders
 * KSM-665 - Add HTTP Status Code to the error messages
 * KSM-701 - Write config files with secure permissions (0600)
-* KSM-658 - Add custom cache example and document ICache interface
 * KSM-736 - Fix notation lookup with record shortcuts (duplicate UID bug)
 * KSM-745 - Add transmission public key #18 for Gov Cloud Dev support
+* KSM-756 - Fix shared-folder flat records decrypting with wrong key (folder vs app key)
+* KSM-826 - Fix RecordCreate.ToDict() to always include "custom" key
+* KSM-860 - Fix RecordField JSON serialization (lowercase keys, no double-nesting)
+* KSM-911 - Skip records whose AES-GCM data decryption fails instead of returning empty stubs
+* KSM-912 - Fix proxy env var fallback (HTTPS_PROXY/HTTP_PROXY now respected)
 
 ## 1.6.5
 

--- a/core/dtos.go
+++ b/core/dtos.go
@@ -441,7 +441,8 @@ func NewRecordFromJson(recordDict map[string]interface{}, secretKey []byte, fold
 		if recordKeyBytes, err := Decrypt(recordKeyEncryptedBytes, secretKey); err == nil {
 			record.RecordKeyBytes = recordKeyBytes
 		} else {
-			klog.Error("error decrypting record key: " + err.Error() + " - Record UID: " + record.Uid)
+			klog.Error("error decrypting record key for UID " + record.Uid + ": " + err.Error())
+			return nil
 		}
 	} else {
 		//Single Record Share

--- a/core/dtos.go
+++ b/core/dtos.go
@@ -454,7 +454,8 @@ func NewRecordFromJson(recordDict map[string]interface{}, secretKey []byte, fold
 			record.RawJson = recordDataJson
 			record.RecordDict = JsonToDict(record.RawJson)
 		} else {
-			klog.Error("error decrypting record data: " + err.Error())
+			klog.Error("error decrypting record data for UID " + record.Uid + ": " + err.Error())
+			return nil
 		}
 	}
 

--- a/example/ksm.go
+++ b/example/ksm.go
@@ -36,6 +36,10 @@ func main() {
 		}
 	}
 
+	if len(allRecords) == 0 {
+		klog.Info("No records returned")
+		os.Exit(0)
+	}
 	recToUpdate := allRecords[0]
 
 	passwordField := map[string]interface{}{}

--- a/test/mock_test.go
+++ b/test/mock_test.go
@@ -390,6 +390,7 @@ type MockRecord struct {
 	CustomFields []map[string]interface{}
 	FolderUid    string // when set, added to Dump() output and FolderKey used for encryption
 	FolderKey    []byte // when set, used instead of secret for record key and data encryption
+	CorruptData  bool   // when set, data field is random bytes so AES-GCM decryption fails
 }
 
 func NewMockRecord(recordType, uid, title string) *MockRecord {
@@ -561,8 +562,14 @@ func (r *MockRecord) Dump(secret []byte, flags *MockFlags) map[string]interface{
 		encKey = r.FolderKey
 	}
 
-	encData, _ := core.EncryptAesGcm([]byte(jsonData), encKey)
-	recordData := core.BytesToBase64(encData)
+	var recordData string
+	if r.CorruptData {
+		junk, _ := core.GetRandomBytes(48)
+		recordData = core.BytesToBase64(junk)
+	} else {
+		encData, _ := core.EncryptAesGcm([]byte(jsonData), encKey)
+		recordData = core.BytesToBase64(encData)
+	}
 
 	recKey, _ := core.EncryptAesGcm(encKey, encKey)
 	recordKey := core.BytesToBase64(recKey)

--- a/test/mock_test.go
+++ b/test/mock_test.go
@@ -391,6 +391,7 @@ type MockRecord struct {
 	FolderUid    string // when set, added to Dump() output and FolderKey used for encryption
 	FolderKey    []byte // when set, used instead of secret for record key and data encryption
 	CorruptData  bool   // when set, data field is random bytes so AES-GCM decryption fails
+	CorruptKey   bool   // when set, recordKey field is random bytes so key decryption fails
 }
 
 func NewMockRecord(recordType, uid, title string) *MockRecord {
@@ -571,8 +572,14 @@ func (r *MockRecord) Dump(secret []byte, flags *MockFlags) map[string]interface{
 		recordData = core.BytesToBase64(encData)
 	}
 
-	recKey, _ := core.EncryptAesGcm(encKey, encKey)
-	recordKey := core.BytesToBase64(recKey)
+	var recordKey string
+	if r.CorruptKey {
+		junk, _ := core.GetRandomBytes(48)
+		recordKey = core.BytesToBase64(junk)
+	} else {
+		recKey, _ := core.EncryptAesGcm(encKey, encKey)
+		recordKey = core.BytesToBase64(recKey)
+	}
 
 	data := map[string]interface{}{
 		"recordUid":  r.Uid,

--- a/test/record_test.go
+++ b/test/record_test.go
@@ -181,3 +181,75 @@ func TestDecryptionFailureSkipsRecord(t *testing.T) {
 		t.Errorf("expected good-uid record, got %q", records[0].Uid)
 	}
 }
+
+// KSM-911: GetSecrets must skip records whose AES-GCM key decryption fails.
+// A corrupted recordKey means RecordKeyBytes is never set; previously the record
+// was silently returned as a stub with no field data.
+func TestKeyDecryptionFailureSkipsRecord(t *testing.T) {
+	defer ResetMockResponseQueue()
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+
+	res := NewMockResponse([]byte{}, 200, nil)
+
+	// Good record — decrypts normally.
+	res.AddRecord("Good Record", "login", "good-uid", nil, nil)
+
+	// Bad record — recordKey is random bytes so key decryption fails before data is attempted.
+	bad := NewMockRecord("login", "bad-key-uid", "Bad Key Record")
+	bad.CorruptKey = true
+	res.Records[bad.Uid] = bad
+
+	MockResponseQueue.AddMockResponse(res)
+
+	records, err := sm.GetSecrets([]string{})
+	if err != nil {
+		t.Fatalf("GetSecrets returned unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Errorf("expected 1 record (bad-key record should be skipped), got %d", len(records))
+	}
+	if len(records) == 1 && records[0].Uid != "good-uid" {
+		t.Errorf("expected good-uid record, got %q", records[0].Uid)
+	}
+}
+
+// KSM-911: GetSecrets must skip both corrupted-key and corrupted-data records,
+// returning only the healthy records from a mixed response.
+func TestMixedDecryptionFailuresSkipBadRecords(t *testing.T) {
+	defer ResetMockResponseQueue()
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+
+	res := NewMockResponse([]byte{}, 200, nil)
+
+	res.AddRecord("Good Record 1", "login", "good-1", nil, nil)
+	res.AddRecord("Good Record 2", "login", "good-2", nil, nil)
+
+	badData := NewMockRecord("login", "bad-data", "Bad Data")
+	badData.CorruptData = true
+	res.Records[badData.Uid] = badData
+
+	badKey := NewMockRecord("login", "bad-key", "Bad Key")
+	badKey.CorruptKey = true
+	res.Records[badKey.Uid] = badKey
+
+	MockResponseQueue.AddMockResponse(res)
+
+	records, err := sm.GetSecrets([]string{})
+	if err != nil {
+		t.Fatalf("GetSecrets returned unexpected error: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("expected 2 records (both bad records should be skipped), got %d", len(records))
+	}
+	for _, r := range records {
+		if r.Uid != "good-1" && r.Uid != "good-2" {
+			t.Errorf("unexpected record in result: %q", r.Uid)
+		}
+	}
+}

--- a/test/record_test.go
+++ b/test/record_test.go
@@ -148,3 +148,36 @@ func TestRecordCreateToDictAlwaysIncludesCustom(t *testing.T) {
 		t.Error("ToDict() missing 'custom' key when Custom is empty")
 	}
 }
+
+// KSM-911: GetSecrets must skip records whose AES-GCM data decryption fails.
+// Before this fix, a failed decryption produced an empty record stub appended to the result.
+func TestDecryptionFailureSkipsRecord(t *testing.T) {
+	defer ResetMockResponseQueue()
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+
+	res := NewMockResponse([]byte{}, 200, nil)
+
+	// Good record — decrypts normally.
+	res.AddRecord("Good Record", "login", "good-uid", nil, nil)
+
+	// Bad record — data is random bytes so AES-GCM authentication fails.
+	bad := NewMockRecord("login", "bad-uid", "Bad Record")
+	bad.CorruptData = true
+	res.Records[bad.Uid] = bad
+
+	MockResponseQueue.AddMockResponse(res)
+
+	records, err := sm.GetSecrets([]string{})
+	if err != nil {
+		t.Fatalf("GetSecrets returned unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Errorf("expected 1 record (bad record should be skipped), got %d", len(records))
+	}
+	if len(records) == 1 && records[0].Uid != "good-uid" {
+		t.Errorf("expected good-uid record, got %q", records[0].Uid)
+	}
+}


### PR DESCRIPTION
## Summary

When \`GetSecrets()\` encountered a record whose AES-GCM decryption failed, \`NewRecordFromJson\` logged the error but still returned a partial \`Record\` stub — valid UID, empty field data. The append guard in \`core.go\` checked \`record != nil && record.Uid != ""\`, which was always true (UID comes from the outer JSON wrapper before decryption), so the empty stub was included in the result with no way for callers to detect it.

Two decryption failure paths were affected:
1. **Record data decryption** — \`DecryptRecord\` failure on the \`data\` field
2. **Record key decryption** — \`Decrypt\` failure on the \`recordKey\` field (leaves \`RecordKeyBytes\` empty, data block is skipped, stub returned)

## Changes

### Fixed
- \`NewRecordFromJson\` returns \`nil\` on \`DecryptRecord\` failure (data path), includes affected UID in error log (KSM-911)
- \`NewRecordFromJson\` returns \`nil\` on \`Decrypt\` failure (key path), includes affected UID in error log (KSM-911)

### Tests
- \`TestDecryptionFailureSkipsRecord\` — corrupted \`data\` field, expects bad record skipped
- \`TestKeyDecryptionFailureSkipsRecord\` — corrupted \`recordKey\` field, expects bad record skipped
- \`TestMixedDecryptionFailuresSkipBadRecords\` — 2 good + 1 bad-data + 1 bad-key, expects exactly 2 records returned
- \`MockRecord.CorruptData\` and \`MockRecord.CorruptKey\` flags added to mock infrastructure

### Maintenance
- \`README.md\` changelog: add missing v1.7.0 entries (KSM-756, KSM-826, KSM-860, KSM-911, KSM-912)
- \`README.md\` Quick Start example: guard \`allRecords[0]\` access with a length check
- \`example/ksm.go\`: guard \`allRecords[0]\` access with a length check before update loop

## Testing

\`\`\`bash
cd test && go test -p 1 -v -run "TestDecryptionFailureSkipsRecord|TestKeyDecryptionFailureSkipsRecord|TestMixedDecryptionFailuresSkipBadRecords"
cd test && go test -p 1 ./...
\`\`\`

All three regression tests pass. Full suite passes.

## Breaking Changes

None. Previously callers could receive empty record stubs for failed decryptions; now those records are omitted from the slice. This is a correction of incorrect behavior.

## Related Issues

- Jira: KSM-911