### PR TITLE
KSM-913: return nil from NewFolderFromJson and NewKeeperFolder on decryption failure

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1036,10 +1036,8 @@ func (c *SecretsManager) fetchAndDecryptFolders() (folders []*KeeperFolder, err 
 				}
 
 				folder := NewKeeperFolder(fmap, fkey)
-				if f != nil {
+				if folder != nil {
 					folders = append(folders, folder)
-				} else {
-					klog.Error("error parsing folder JSON: ", f)
 				}
 			}
 		} else {

--- a/core/dtos.go
+++ b/core/dtos.go
@@ -1102,8 +1102,11 @@ func NewKeeperFolder(folderMap map[string]interface{}, folderKey []byte) *Keeper
 				if err := json.Unmarshal(folderNameJson, &folderName); err == nil {
 					folder.Name = folderName.Name
 				} else {
-					klog.Error("error parsing folder name: " + err.Error())
+					klog.Error("error parsing folder name for " + folder.FolderUid + ": " + err.Error())
 				}
+			} else {
+				klog.Error("error decrypting folder name for " + folder.FolderUid + ": " + err.Error())
+				return nil
 			}
 		}
 	}
@@ -1142,7 +1145,8 @@ func NewFolderFromJson(folderDict map[string]interface{}, secretKey []byte) *Fol
 					}
 				}
 			} else {
-				klog.Error("error decrypting folder key: " + err.Error())
+				klog.Error("error decrypting folder key for " + folder.uid + ": " + err.Error())
+				return nil
 			}
 		}
 	} else {
@@ -1170,7 +1174,11 @@ func (f *Folder) Records() []*Record {
 				if record := NewRecordFromJson(r, f.key, f.uid); record != nil && record.Uid != "" {
 					records = append(records, record)
 				} else {
-					klog.Error("error parsing folder record: ", r)
+					if uid, ok := r["recordUid"]; ok {
+						klog.Error(fmt.Sprintf("Record %s in folder %s skipped: decryption failed", uid, f.uid))
+					} else {
+						klog.Error(fmt.Sprintf("Record in folder %s skipped: decryption failed", f.uid))
+					}
 				}
 			}()
 		}

--- a/test/mock_test.go
+++ b/test/mock_test.go
@@ -249,9 +249,10 @@ func GetRandomUid() (uid string, err error) {
 }
 
 type MockFolder struct {
-	Uid     string
-	Records map[string]interface{}
-	Key     []byte // distinct folder key, encrypted with app key when dumped
+	Uid        string
+	Records    map[string]interface{}
+	Key        []byte // distinct folder key, encrypted with app key when dumped
+	CorruptKey bool   // when set, folderKey field is random bytes so key decryption fails
 }
 
 func NewMockFolder(uid string) *MockFolder {
@@ -275,9 +276,14 @@ func (f *MockFolder) AddRecord(title, recordType, uid string, record *MockRecord
 }
 
 func (f *MockFolder) Dump(secret []byte, flags *MockFlags) map[string]interface{} {
-	// Encrypt the folder key with the app key, as the backend does in production.
-	encFolderKey, _ := core.EncryptAesGcm(f.Key, secret)
-	folderKey := core.BytesToBase64(encFolderKey)
+	var folderKey string
+	if f.CorruptKey {
+		junk, _ := core.GetRandomBytes(48)
+		folderKey = core.BytesToBase64(junk)
+	} else {
+		encFolderKey, _ := core.EncryptAesGcm(f.Key, secret)
+		folderKey = core.BytesToBase64(encFolderKey)
+	}
 
 	records := []interface{}{}
 	for _, record := range f.Records {

--- a/test/record_test.go
+++ b/test/record_test.go
@@ -253,3 +253,54 @@ func TestMixedDecryptionFailuresSkipBadRecords(t *testing.T) {
 		}
 	}
 }
+
+// KSM-913: NewFolderFromJson must return nil when folder key decryption fails.
+// Before this fix, it returned a non-nil stub with an empty key and no records,
+// giving callers no way to detect the failure.
+func TestNewFolderFromJsonNilOnCorruptKey(t *testing.T) {
+	secretKey, _ := ksm.GetRandomBytes(32)
+	junk, _ := ksm.GetRandomBytes(48)
+
+	folderDict := map[string]interface{}{
+		"folderUid": "test-folder-uid",
+		"folderKey": ksm.BytesToBase64(junk), // random bytes — key decryption must fail
+		"records":   []interface{}{},
+	}
+
+	if folder := ksm.NewFolderFromJson(folderDict, secretKey); folder != nil {
+		t.Error("expected nil from NewFolderFromJson on corrupt folder key, got non-nil stub")
+	}
+}
+
+// KSM-913: GetSecrets must not return records from a folder whose key is corrupt.
+// This verifies end-to-end that the nil return from NewFolderFromJson propagates
+// correctly through fetchAndDecryptSecrets.
+func TestFolderKeyDecryptionFailureSkipsFolder(t *testing.T) {
+	defer ResetMockResponseQueue()
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+
+	res := NewMockResponse([]byte{}, 200, nil)
+
+	res.AddRecord("Good Record", "login", "good-uid", nil, nil)
+
+	badFolder := NewMockFolder("bad-folder-uid")
+	badFolder.CorruptKey = true
+	badFolder.AddRecord("Folder Record", "login", "folder-record-uid", nil)
+	res.Folders[badFolder.Uid] = badFolder
+
+	MockResponseQueue.AddMockResponse(res)
+
+	records, err := sm.GetSecrets([]string{})
+	if err != nil {
+		t.Fatalf("GetSecrets returned unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Errorf("expected 1 record (bad folder should be skipped), got %d", len(records))
+	}
+	if len(records) == 1 && records[0].Uid != "good-uid" {
+		t.Errorf("expected good-uid, got %q", records[0].Uid)
+	}
+}


### PR DESCRIPTION
## Summary

`NewFolderFromJson` and `NewKeeperFolder` silently returned non-nil stubs when decryption failed, giving callers no way to detect the failure. Both now return nil on failure, consistent with the KSM-911 fix for records. Also fixes a latent nil-guard bug in `core.go` that would have caused a panic once `NewKeeperFolder` could return nil.

## Changes

### Fixed
- `NewFolderFromJson`: returns nil when folder key decryption fails instead of a stub with an empty key and no records (KSM-913)
- `NewKeeperFolder`: returns nil when folder name decryption fails instead of a stub with an empty Name (KSM-913)
- `core.go` GetFolders loop: nil guard now checks `folder` (the result of `NewKeeperFolder`) instead of `f` (the loop variable, always non-nil) — latent panic prevention (KSM-913)
- `Folder.Records()`: error log now reports only the record UID instead of dumping the full raw encrypted record map (KSM-913)

## Testing

```bash
cd test && go test -p 1 ./...
```

New regression tests:
- `TestNewFolderFromJsonNilOnCorruptKey` — directly asserts nil return when folder key is corrupt
- `TestFolderKeyDecryptionFailureSkipsFolder` — end-to-end via GetSecrets

## Breaking Changes
None.

## Related Issues
- Jira: KSM-913