### PR TITLE
KSM-914: return nil from NewKeeperFileFromJson when file key decryption fails

### DIFF
--- a/core/dtos.go
+++ b/core/dtos.go
@@ -1209,6 +1209,10 @@ func NewKeeperFileFromJson(fileDict map[string]interface{}, recordKeyBytes []byt
 		RecordKeyBytes: recordKeyBytes,
 	}
 
+	if len(f.DecryptFileKey()) == 0 {
+		return nil
+	}
+
 	// Set file metadata
 	meta := f.GetMeta()
 
@@ -1258,7 +1262,7 @@ func (f *KeeperFile) DecryptFileKey() []byte {
 		return fileKey
 	} else {
 		klog.Error("error decrypting file key " + fileKeyEncryptedBase64Str)
-		return []byte{}
+		return nil
 	}
 }
 
@@ -1267,6 +1271,9 @@ func (f *KeeperFile) GetMeta() map[string]interface{} {
 	if len(f.metaDict) == 0 {
 		if data, ok := f.F["data"]; ok && data != nil {
 			fileKey := f.DecryptFileKey()
+			if len(fileKey) == 0 {
+				return f.metaDict
+			}
 			dataStr := fmt.Sprintf("%v", data)
 			if metaJson, err := Decrypt(Base64ToBytes(dataStr), fileKey); err == nil {
 				f.metaDict = JsonToDict(string(metaJson[:]))
@@ -1296,6 +1303,8 @@ func (f *KeeperFile) GetFileData() []byte {
 				if fileEncryptedData, err := io.ReadAll(rs.Body); err == nil {
 					if fileData, err := Decrypt(fileEncryptedData, fileKey); err == nil {
 						f.FileData = fileData
+					} else {
+						klog.Error("error decrypting file data for " + f.Uid + ": " + err.Error())
 					}
 				}
 			}

--- a/test/mock_test.go
+++ b/test/mock_test.go
@@ -303,15 +303,16 @@ func (f *MockFolder) Dump(secret []byte, flags *MockFlags) map[string]interface{
 }
 
 type MockFile struct {
-	Uid          string
-	SecretUsed   []byte
-	Name         string
-	Title        string
-	ContentType  string
-	Url          string
-	Content      []byte
-	Size         int
-	LastModified int
+	Uid            string
+	SecretUsed     []byte
+	Name           string
+	Title          string
+	ContentType    string
+	Url            string
+	Content        []byte
+	Size           int
+	LastModified   int
+	CorruptFileKey bool // when set, fileKey field is random bytes so key decryption fails
 }
 
 func NewMockFile(name, title, contentType, url string, content []byte, lastModified int) *MockFile {
@@ -371,8 +372,14 @@ func (f *MockFile) Dump(secret []byte, flags *MockFlags) map[string]interface{} 
 	encData, _ := core.EncryptAesGcm([]byte(data), secret)
 	recordData := core.BytesToBase64(encData)
 
-	encFileKey, _ := core.EncryptAesGcm(secret, secret)
-	fileKey := core.BytesToBase64(encFileKey)
+	var fileKey string
+	if f.CorruptFileKey {
+		junk, _ := core.GetRandomBytes(48)
+		fileKey = core.BytesToBase64(junk)
+	} else {
+		encFileKey, _ := core.EncryptAesGcm(secret, secret)
+		fileKey = core.BytesToBase64(encFileKey)
+	}
 
 	fileData := map[string]interface{}{
 		"fileUid":      f.Uid,

--- a/test/record_test.go
+++ b/test/record_test.go
@@ -304,3 +304,51 @@ func TestFolderKeyDecryptionFailureSkipsFolder(t *testing.T) {
 		t.Errorf("expected good-uid, got %q", records[0].Uid)
 	}
 }
+
+// KSM-914: NewKeeperFileFromJson must return nil when file key decryption fails.
+// Before this fix, it returned a non-nil stub with empty metadata and no way for
+// callers to detect the failure.
+func TestNewKeeperFileFromJsonNilOnCorruptKey(t *testing.T) {
+	recordKey, _ := ksm.GetRandomBytes(32)
+	junk, _ := ksm.GetRandomBytes(48)
+
+	fileDict := map[string]interface{}{
+		"fileUid": "test-file-uid",
+		"fileKey": ksm.BytesToBase64(junk),
+		"data":    ksm.BytesToBase64(junk),
+		"url":     "",
+	}
+
+	if file := ksm.NewKeeperFileFromJson(fileDict, recordKey); file != nil {
+		t.Error("expected nil from NewKeeperFileFromJson on corrupt file key, got non-nil stub")
+	}
+}
+
+// KSM-914: GetSecrets must not include files whose key decryption fails.
+// The record itself is still returned; only the bad file is dropped from record.Files.
+func TestFileKeyDecryptionFailureSkipsFile(t *testing.T) {
+	defer ResetMockResponseQueue()
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+
+	res := NewMockResponse([]byte{}, 200, nil)
+
+	rec := res.AddRecord("Record With Bad File", "login", "rec-uid", nil, nil)
+	badFile := rec.AddFile("secret.txt", "", "", "", nil, 0)
+	badFile.CorruptFileKey = true
+
+	MockResponseQueue.AddMockResponse(res)
+
+	records, err := sm.GetSecrets([]string{})
+	if err != nil {
+		t.Fatalf("GetSecrets returned unexpected error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Errorf("expected 1 record, got %d", len(records))
+	}
+	if len(records) == 1 && len(records[0].Files) != 0 {
+		t.Errorf("expected 0 files (bad file key should be skipped), got %d", len(records[0].Files))
+	}
+}


### PR DESCRIPTION
## Summary

\`NewKeeperFileFromJson\` silently returned a non-nil stub when file key decryption failed, giving callers no way to detect the failure. Follows the same fix pattern as KSM-911 (records) and KSM-913 (folders): return nil on decryption failure so the file is cleanly skipped.

## Changes

### Fixed
- \`DecryptFileKey()\`: returns \`nil\` instead of \`[]byte{}\` on failure — consistent with Go nil-sentinel conventions (KSM-914)
- \`GetMeta()\`: short-circuits when file key is empty, avoiding a misleading "error parsing file meta data" log that masked the real cause (KSM-914)
- \`NewKeeperFileFromJson()\`: returns \`nil\` when file key decryption fails; the caller in \`NewRecordFromJson\` already guards on \`file != nil\`, so bad files are silently dropped from \`record.Files\` (KSM-914)
- \`GetFileData()\`: logs an error when file data decryption fails instead of returning empty bytes silently (KSM-914)

## Testing

```bash
cd test && go test -p 1 ./...
```

New regression tests:
- \`TestNewKeeperFileFromJsonNilOnCorruptKey\` — directly asserts nil return when file key is corrupt (failed before fix)
- \`TestFileKeyDecryptionFailureSkipsFile\` — end-to-end via GetSecrets: record returned, bad file dropped from Files

## Breaking Changes
None.

## Related Issues
- Jira: KSM-914