### PR TITLE
fix(sdk/golang): return nil from NewKeeperFolder when folder name fails JSON unmarshal (KSM-917)

### DIFF
--- a/core/dtos.go
+++ b/core/dtos.go
@@ -1103,6 +1103,7 @@ func NewKeeperFolder(folderMap map[string]interface{}, folderKey []byte) *Keeper
 					folder.Name = folderName.Name
 				} else {
 					klog.Error("error parsing folder name for " + folder.FolderUid + ": " + err.Error())
+					return nil
 				}
 			} else {
 				klog.Error("error decrypting folder name for " + folder.FolderUid + ": " + err.Error())

--- a/test/record_test.go
+++ b/test/record_test.go
@@ -352,3 +352,22 @@ func TestFileKeyDecryptionFailureSkipsFile(t *testing.T) {
 		t.Errorf("expected 0 files (bad file key should be skipped), got %d", len(records[0].Files))
 	}
 }
+
+// KSM-917: NewKeeperFolder must return nil when CBC decryption produces garbage that
+// fails json.Unmarshal. Before this fix, it logged the error but returned a non-nil
+// stub with Name = "", indistinguishable from a legitimately empty-named folder.
+func TestNewKeeperFolderNilOnUnmarshalFailure(t *testing.T) {
+	folderKey, _ := ksm.GetRandomBytes(32)
+	notJSON := []byte("not-json-garbage!!!")
+	encrypted, err := ksm.EncryptAesCbc(notJSON, folderKey)
+	if err != nil {
+		t.Fatalf("EncryptAesCbc failed: %v", err)
+	}
+	folderMap := map[string]interface{}{
+		"folderUid": "test-folder-uid-917",
+		"data":      ksm.BytesToUrlSafeStr(encrypted),
+	}
+	if folder := ksm.NewKeeperFolder(folderMap, folderKey); folder != nil {
+		t.Errorf("expected nil from NewKeeperFolder when CBC decrypts to non-JSON, got non-nil stub with Name=%q", folder.Name)
+	}
+}


### PR DESCRIPTION
## Summary

`NewKeeperFolder` logged the error when `json.Unmarshal` failed on a CBC-decrypted folder name but fell through to return a non-nil `*KeeperFolder` with `Name = ""`. This stub is indistinguishable from a legitimately empty-named folder. Add `return nil` on the unmarshal failure path, completing the nil-return contract KSM-913 established for the `DecryptAesCbc` failure path in the same function.

## Changes

### Fixed
- `NewKeeperFolder` returns `nil` when CBC decryption produces garbage bytes that fail `json.Unmarshal` (KSM-917)

## Testing

```bash
cd test && go test -p 1 ./...
```

## Breaking Changes
None.

## Related Issues
- Jira: KSM-917