### PR TITLE
fix: expose HTTP status code via KeeperHTTPError on JSON-error path (KSM-919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ The SDK now uses `io` and `os` in place of the deprecated `ioutil` package. Requ
 2. Update CI/CD base images (`golang:1.15-*` and earlier will fail to build).
 3. Ensure your `go.mod` declares `go 1.16` or higher.
 
+**HTTP error string format change** (KSM-919)
+
+`GetSecrets` and other API methods now return `*core.KeeperHTTPError` for all non-200 responses. The `Error()` string on the JSON-error path now includes the HTTP status code (e.g. `"POST Error: HTTPStatus=403 Error: access_denied, message=..."`) matching the format already used on the non-JSON path. Code that string-matched `"POST Error: Error: access_denied, ..."` (without the status prefix) will no longer match. Migrate to `errors.As`:
+
+```go
+var khe *core.KeeperHTTPError
+if errors.As(err, &khe) {
+    // khe.StatusCode, khe.ResultCode, khe.Message
+}
+```
+
 **Behavioral changes: error handling on decryption failure**
 
 The following functions previously returned non-nil empty stubs on decryption failure and now return `nil`. Callers that did not nil-check the return value will panic on dereference. Audit usage of:
@@ -65,6 +76,7 @@ The following functions previously returned non-nil empty stubs on decryption fa
 **Network and runtime**
 
 - `HTTPS_PROXY`/`HTTP_PROXY` environment variables are now honored when `ProxyUrl` is not explicitly set, matching standard `net/http` behavior. Previously these variables were silently ignored. (KSM-912)
+- HTTP status code is now included in the caller-returned error on the JSON-error path. Previously it appeared only in the log line and the non-JSON fallback; callers on the common 4xx/5xx JSON path received no status code in `err.Error()`. (KSM-919)
 - Replaced `strings.Cut()` (Go 1.18+) with `strings.SplitN()` throughout. Users on Go 1.16 or 1.17 would have seen build failures with the previous code.
 
 ---
@@ -73,7 +85,7 @@ The following functions previously returned non-nil empty stubs on decryption fa
 
 - KSM tokens with a region prefix are now parsed correctly: `US:`, `EU:`, `AU:`, `GOV:`, `JP:`, `CA:`. The prefix sets the server hostname automatically; no separate `Hostname` option is required. (KSM-565)
 - HTTP proxy support added via `ClientOptions.ProxyUrl`. When `ProxyUrl` is not set, `HTTPS_PROXY`/`HTTP_PROXY` environment variables are honored automatically. (KSM-532)
-- HTTP error responses now include the status code in the error message. Format: `HTTP <code>: <body>`. Code that string-matches error messages may need updating. (KSM-665)
+- HTTP error responses include the HTTP status code in the error message and as a structured field. All non-200 API errors are returned as `*core.KeeperHTTPError` with `StatusCode`, `ResultCode`, and `Message` fields accessible via `errors.As`. (KSM-665, KSM-919)
 - `links2Remove` parameter added to support removing file attachment links when updating records. (KSM-632)
 - GraphSync link sharing support added for applications that resolve and share records via GraphSync. (KSM-626)
 - `SetNotes` now uses UPSERT behavior: it creates the notes field if it does not exist on the record, in addition to updating it. Previously it silently no-op'd on records without an existing notes field. (KSM-583)

--- a/core/core.go
+++ b/core/core.go
@@ -846,13 +846,12 @@ func (c *SecretsManager) PostQuery(path string, payload interface{}) (body []byt
 		}
 
 		// Handle the error. Handler will return a retry status if it is a recoverable error.
-		if retry, err := c.HandleHttpError(ksmRs.HttpResponse, ksmRs.Data, err); !retry {
-			errMsg := "N/A"
-			if err != nil {
-				errMsg = err.Error()
+		if retry, httpErr := c.HandleHttpError(ksmRs.HttpResponse, ksmRs.Data, err); !retry {
+			if httpErr == nil {
+				httpErr = errors.New("N/A")
 			}
-			klog.Error("POST Error: " + errMsg)
-			return nil, errors.New("POST Error: " + errMsg)
+			klog.Error("POST Error: " + httpErr.Error())
+			return nil, fmt.Errorf("POST Error: %w", httpErr)
 		}
 	}
 
@@ -923,22 +922,28 @@ func (c *SecretsManager) HandleHttpError(rs *http.Response, body []byte, httpErr
 
 	responseDict := JsonToDict(string(body))
 	if len(responseDict) == 0 {
-		// This is an unknown error, not one of ours, just throw a HTTPError
-		return false, fmt.Errorf("HTTPStatus=%v HTTPError: %v", rs.StatusCode, string(body))
+		// Non-JSON body — unknown error not from the Keeper backend.
+		return false, &KeeperHTTPError{StatusCode: rs.StatusCode, Body: body}
 	}
 
 	// Try to get the error from result_code, then from error.
-	msg := ""
 	rc, found := responseDict["result_code"]
 	if !found {
 		rc, found = responseDict["error"]
 	}
-	if found && rc.(string) == "invalid_client_version" {
+	rcStr := ""
+	if found {
+		rcStr = fmt.Sprintf("%v", rc)
+	}
+
+	if found && rcStr == "invalid_client_version" {
 		klog.Error(fmt.Sprintf("Client version %s was not registered in the backend", keeperSecretsManagerClientId))
-		if additionalInfo, found := responseDict["additional_info"]; found {
-			msg = additionalInfo.(string)
+		additionalInfo := ""
+		if ai, ok := responseDict["additional_info"]; ok {
+			additionalInfo = fmt.Sprintf("%v", ai)
 		}
-	} else if found && rc.(string) == "key" {
+		return false, &KeeperHTTPError{StatusCode: rs.StatusCode, ResultCode: rcStr, Message: additionalInfo}
+	} else if found && rcStr == "key" {
 		// The server wants us to use a different public key.
 		keyId := ""
 		if kid, ok := responseDict["key_id"]; ok {
@@ -946,33 +951,26 @@ func (c *SecretsManager) HandleHttpError(rs *http.Response, body []byte, httpErr
 		}
 		klog.Info(fmt.Sprintf("Server has requested we use public key %v", keyId))
 		if len(keyId) == 0 {
-			msg = "The public key is blank from the server"
+			return false, &KeeperHTTPError{StatusCode: rs.StatusCode, ResultCode: rcStr, Message: "the public key is blank from the server"}
 		} else if _, found := keeperServerPublicKeys[keyId]; found {
 			if cfg := c.Config.Set(KEY_SERVER_PUBLIC_KEY_ID, keyId); len(cfg) > 0 {
 				// The only normal exit from this method
 				return true, nil
-			} else {
-				// read-only or inaccessible configuration
-				return false, errors.New("failed to switch the server public key")
 			}
-		} else {
-			msg = fmt.Sprintf("The public key at %v does not exist in the SDK", keyId)
+			// read-only or inaccessible configuration
+			return false, errors.New("failed to switch the server public key")
 		}
-	} else {
-		responseMsg, ok := responseDict["message"]
-		if !ok {
-			responseMsg = "N/A"
+		return false, &KeeperHTTPError{StatusCode: rs.StatusCode, ResultCode: rcStr, Message: fmt.Sprintf("the public key at %v does not exist in the SDK", keyId)}
+	} else if found {
+		responseMsg := "N/A"
+		if m, ok := responseDict["message"]; ok {
+			responseMsg = fmt.Sprintf("%v", m)
 		}
-		msg = fmt.Sprintf("Error: %v, message=%v", rc, responseMsg)
+		return false, &KeeperHTTPError{StatusCode: rs.StatusCode, ResultCode: rcStr, Message: responseMsg}
 	}
 
-	if msg != "" {
-		err = errors.New(msg)
-	} else if len(body) > 0 {
-		err = errors.New(string(body))
-	}
-
-	return
+	// JSON body present but no result_code/error field — return raw body.
+	return false, &KeeperHTTPError{StatusCode: rs.StatusCode, Body: body}
 }
 
 func GetSharedFolderKey(folders []*KeeperFolder, responseFolders []interface{}, parent string) []byte {

--- a/core/errors.go
+++ b/core/errors.go
@@ -1,0 +1,38 @@
+package core
+
+import "fmt"
+
+// KeeperHTTPError is returned by PostQuery (and thus GetSecrets, GetFolders, etc.)
+// whenever the Keeper API responds with a non-200 status code.
+//
+// Callers that need to branch on the HTTP status code should use errors.As:
+//
+//	var khe *core.KeeperHTTPError
+//	if errors.As(err, &khe) {
+//	    switch khe.StatusCode {
+//	    case 401, 403:
+//	        // handle auth failure
+//	    case 429:
+//	        // handle rate limit
+//	    }
+//	}
+type KeeperHTTPError struct {
+	// StatusCode is the HTTP status code returned by the server (e.g. 403, 502).
+	StatusCode int
+	// ResultCode is the machine-readable error code from the JSON envelope
+	// (the "result_code" or "error" field). Empty when the body was not JSON.
+	ResultCode string
+	// Message is the human-readable explanation from the JSON envelope.
+	// Empty when the body was not JSON.
+	Message string
+	// Body holds the raw response body when the server did not return a
+	// parseable JSON error envelope. Nil for structured JSON errors.
+	Body []byte
+}
+
+func (e *KeeperHTTPError) Error() string {
+	if len(e.Body) > 0 && e.ResultCode == "" {
+		return fmt.Sprintf("HTTPStatus=%d HTTPError: %s", e.StatusCode, string(e.Body))
+	}
+	return fmt.Sprintf("HTTPStatus=%d Error: %s, message=%s", e.StatusCode, e.ResultCode, e.Message)
+}

--- a/test/exception_test.go
+++ b/test/exception_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,7 +12,7 @@ func TestOurException(t *testing.T) {
 	// Exceptions the Secrets Manager server will send that have meaning.
 	defer func() {
 		if r := recover(); r != nil {
-			expectedMsg := "POST Error: Error: access_denied, message=Signature is invalid"
+			expectedMsg := "POST Error: HTTPStatus=403 Error: access_denied, message=Signature is invalid"
 			if msg, ok := r.(string); ok && strings.TrimSpace(msg) == expectedMsg {
 				t.Log("Received expected error code 403 'Signature is invalid'")
 			} else {
@@ -37,10 +38,28 @@ func TestOurException(t *testing.T) {
 
 	MockResponseQueue.AddMockResponse(NewMockResponse([]byte(errorJson), 403, nil))
 
-	if _, err := sm.GetSecrets(nil); err != nil && err.Error() == "POST Error: Error: access_denied, message=Signature is invalid" {
-		t.Log("Received expected error code 403 'Signature is invalid'")
-	} else {
-		t.Error("did not get correct error message")
+	_, err := sm.GetSecrets(nil)
+	expectedMsg := "POST Error: HTTPStatus=403 Error: access_denied, message=Signature is invalid"
+	if err == nil || err.Error() != expectedMsg {
+		t.Errorf("wrong error message: got %q, want %q", err, expectedMsg)
+		return
+	}
+	t.Log("Received expected error code 403 'Signature is invalid'")
+
+	// Verify errors.As exposes the structured fields.
+	var khe *ksm.KeeperHTTPError
+	if !errors.As(err, &khe) {
+		t.Error("errors.As did not find *KeeperHTTPError in chain")
+		return
+	}
+	if khe.StatusCode != 403 {
+		t.Errorf("KeeperHTTPError.StatusCode = %d, want 403", khe.StatusCode)
+	}
+	if khe.ResultCode != "access_denied" {
+		t.Errorf("KeeperHTTPError.ResultCode = %q, want %q", khe.ResultCode, "access_denied")
+	}
+	if khe.Message != "Signature is invalid" {
+		t.Errorf("KeeperHTTPError.Message = %q, want %q", khe.Message, "Signature is invalid")
 	}
 }
 
@@ -64,10 +83,62 @@ func TestNotOurException(t *testing.T) {
 
 	MockResponseQueue.AddMockResponse(NewMockResponse([]byte("Bad Gateway"), 502, nil))
 
-	if _, err := sm.GetSecrets(nil); err != nil && err.Error() == "POST Error: HTTPStatus=502 HTTPError: Bad Gateway" {
-		t.Log("Received expected error code 502 'Bad Gateway'")
-	} else {
-		t.Error("did not get correct error message")
+	_, err := sm.GetSecrets(nil)
+	expectedMsg := "POST Error: HTTPStatus=502 HTTPError: Bad Gateway"
+	if err == nil || err.Error() != expectedMsg {
+		t.Errorf("wrong error message: got %q, want %q", err, expectedMsg)
+		return
+	}
+	t.Log("Received expected error code 502 'Bad Gateway'")
+
+	// Verify errors.As exposes the structured fields.
+	var khe *ksm.KeeperHTTPError
+	if !errors.As(err, &khe) {
+		t.Error("errors.As did not find *KeeperHTTPError in chain")
+		return
+	}
+	if khe.StatusCode != 502 {
+		t.Errorf("KeeperHTTPError.StatusCode = %d, want 502", khe.StatusCode)
+	}
+	if khe.ResultCode != "" {
+		t.Errorf("KeeperHTTPError.ResultCode = %q, want empty (non-JSON body)", khe.ResultCode)
+	}
+	if string(khe.Body) != "Bad Gateway" {
+		t.Errorf("KeeperHTTPError.Body = %q, want %q", string(khe.Body), "Bad Gateway")
+	}
+}
+
+func TestHTTPErrorErrorsAs(t *testing.T) {
+	// Verify that a 429 JSON-error response produces a KeeperHTTPError with the correct status code.
+	defer ResetMockResponseQueue()
+
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+
+	errorJson := `{"error": "throttled", "message": "too many requests"}`
+	MockResponseQueue.AddMockResponse(NewMockResponse([]byte(errorJson), 429, nil))
+
+	_, err := sm.GetSecrets(nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+
+	var khe *ksm.KeeperHTTPError
+	if !errors.As(err, &khe) {
+		t.Fatalf("errors.As did not find *KeeperHTTPError: %v", err)
+	}
+	if khe.StatusCode != 429 {
+		t.Errorf("KeeperHTTPError.StatusCode = %d, want 429", khe.StatusCode)
+	}
+	if khe.ResultCode != "throttled" {
+		t.Errorf("KeeperHTTPError.ResultCode = %q, want %q", khe.ResultCode, "throttled")
+	}
+	if khe.Message != "too many requests" {
+		t.Errorf("KeeperHTTPError.Message = %q, want %q", khe.Message, "too many requests")
+	}
+	if !strings.Contains(err.Error(), "HTTPStatus=429") {
+		t.Errorf("error string %q should contain HTTPStatus=429", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `HandleHttpError` now returns `*KeeperHTTPError` on all non-200 paths (JSON-error, raw-body, and non-JSON), making the HTTP status code reachable via `errors.As` from any caller
- The JSON-error path previously built the error string without the status code; it now produces `"HTTPStatus=N Error: result_code, message=..."` matching the existing non-JSON path format
- The `POST Error:` wrapper switches from `errors.New("POST Error: " + msg)` to `fmt.Errorf("POST Error: %w", err)` so the `*KeeperHTTPError` stays in the chain

Callers can now branch on status programmatically:
```go
var khe *core.KeeperHTTPError
if errors.As(err, &khe) {
    switch khe.StatusCode {
    case 401, 403:
        // auth failure
    case 429:
        // rate limited
    }
}
```

## Breaking Change

`err.Error()` on the JSON-error path now includes `HTTPStatus=N ` as a prefix. Code that string-matched `"POST Error: Error: access_denied, ..."` will no longer match. Migrate to `errors.As`. See CHANGELOG.md for the migration snippet.

## Related Issues

Closes KSM-919
Part of v1.7.0 release (PR #51)