### PR TITLE
fix: KSM-881 one-sided jitter and maxThrottleDelaySec cap

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -938,8 +938,9 @@ func (c *SecretsManager) PostFunction(
 	return NewKsmHttpResponse(rs.StatusCode, rsBody, rs), err
 }
 
-// throttleJitter returns a jitter multiplier in [-0.25, 0.25). It is a package var so tests can pin it.
-var throttleJitter = func() float64 { return rand.Float64()*0.5 - 0.25 }
+// throttleJitter returns a jitter multiplier in [0, 0.25). One-sided so delay is always >= floor,
+// preventing a retry before the backend's 10s memcached window expires. Package var so tests can pin it.
+var throttleJitter = func() float64 { return rand.Float64() * 0.25 }
 
 // parseThrottle reports whether body is a backend throttle error (result_code/error == "throttled")
 // and returns its optional retry_after (seconds, >= 0). It returns (0, false) for any non-throttle
@@ -974,13 +975,16 @@ func parseThrottle(body []byte) (retryAfter float64, throttled bool) {
 
 // throttleDelay computes the backoff delay for a 0-based attempt: retry_after when provided (> 0),
 // otherwise exponential backoff (baseThrottleDelaySec * 2**attempt -> 11s, 22s, 44s, 88s, 176s).
-// A +/-25% jitter is applied to desynchronize concurrent clients retrying at the same time.
+// A 0 to +25% jitter is applied (one-sided so delay is always >= floor).
 func throttleDelay(attempt int, retryAfter float64) time.Duration {
 	var sec float64
 	if retryAfter > 0 {
 		sec = retryAfter
 	} else {
 		sec = float64(baseThrottleDelaySec * (1 << uint(attempt)))
+	}
+	if sec > float64(maxThrottleDelaySec) {
+		sec = float64(maxThrottleDelaySec)
 	}
 	sec += sec * throttleJitter()
 	return time.Duration(sec * float64(time.Second))

--- a/core/keeper_globals.go
+++ b/core/keeper_globals.go
@@ -19,7 +19,8 @@ const (
 // clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every request).
 const (
 	maxThrottleRetries   int = 5
-	baseThrottleDelaySec int = 11 // 1s safety margin over the backend's 10s memcached TTL
+	baseThrottleDelaySec int = 11  // 1s safety margin over the backend's 10s memcached TTL
+	maxThrottleDelaySec  int = 176 // cap on server-supplied retry_after (baseThrottleDelaySec * 2^4)
 )
 
 var (


### PR DESCRIPTION
## Summary

- Fixes symmetric ±25% jitter bug: with floor - 25% = 8.25s, a retry could fire before the backend's 10s memcached window clears, wasting the attempt and resetting the counter. Switch to 0–+25% so the delay is always ≥ the floor.
- Adds `maxThrottleDelaySec = 176` constant in `keeper_globals.go` and applies it as a cap in `throttleDelay` so a server-supplied `retryAfter` above 176s is clamped rather than honored blindly.

## Breaking Changes

None.

## Test plan

- [ ] Existing throttle unit tests still pass (`go test ./...`)
- [ ] Confirm `throttleJitter()` never returns a negative value
- [ ] Confirm `throttleDelay` clamps correctly when `retryAfter > maxThrottleDelaySec`