### PR TITLE
feat(sdk/golang): release Go SDK v1.8.0

### DIFF
--- a/.github/workflows/publish.go.yml
+++ b/.github/workflows/publish.go.yml
@@ -195,7 +195,8 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.16.x", "1.20.x", "1.22.x"]
+        # Keep in step with the matrix in test.go.yml.
+        go-version: ["1.16.x", "1.20.x", "1.22.x", "1.25.x", "1.26.x"]
 
     defaults:
       run:
@@ -232,7 +233,8 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.16.x", "1.20.x", "1.22.x"]
+        # Keep in step with the matrix in test.go.yml.
+        go-version: ["1.16.x", "1.20.x", "1.22.x", "1.25.x", "1.26.x"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scan.govulncheck.yml
+++ b/.github/workflows/scan.govulncheck.yml
@@ -1,0 +1,81 @@
+name: Scan-Go-Vulnerabilities
+
+# govulncheck is the only Go scanner that filters by reachability: it reports a
+# vulnerability solely when the binary can actually reach the affected symbol. That makes
+# its output triaged on arrival, unlike a Dependabot manifest diff.
+#
+# The scan runs on the newest supported Go release rather than the 1.16 floor in
+# core/go.mod. Standard library findings depend on the toolchain doing the building, and a
+# scan on an end-of-life toolchain reports every stdlib defect fixed since, which says
+# nothing about this SDK's own code.
+#
+# Results upload to code scanning rather than failing the job. Dismissing an alert there
+# records who accepted a risk and why, which is the audit trail a release review needs. To
+# make this blocking, require the "Code scanning results" check in branch protection; that
+# keeps the policy decision out of this file.
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'core/**'
+      - 'test/**'
+      - '.github/workflows/scan.govulncheck.yml'
+
+  # New advisories are published against unchanged code, so the scheduled run is where
+  # most findings will come from.
+  schedule:
+    - cron: '17 6 * * 1'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+          cache: false  # core has no external dependencies and no go.sum
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+
+      # The vulnerability database is fetched at run time from vuln.go.dev, so pinning the
+      # tool above does not pin the advisory data.
+      - name: Scan core
+        working-directory: ./core
+        run: govulncheck -format sarif ./... > "${GITHUB_WORKSPACE}/govulncheck-core.sarif"
+
+      - name: Report reachable vulnerabilities
+        run: |
+          count=$(jq '[.runs[0].results[]? | select(.level == "error")] | length' \
+            "${GITHUB_WORKSPACE}/govulncheck-core.sarif")
+          echo "### govulncheck: core" >> "${GITHUB_STEP_SUMMARY}"
+          if [ "${count}" -eq 0 ]; then
+            echo "No reachable vulnerabilities." >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "${count} reachable vulnerabilities. See the Security tab." >> "${GITHUB_STEP_SUMMARY}"
+            jq -r '.runs[0].results[]? | select(.level == "error") | "- \(.ruleId)"' \
+              "${GITHUB_WORKSPACE}/govulncheck-core.sarif" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
+        with:
+          sarif_file: govulncheck-core.sarif
+          category: govulncheck-core

--- a/.github/workflows/test.go.yml
+++ b/.github/workflows/test.go.yml
@@ -12,8 +12,9 @@ jobs:
       contents: read
     strategy:
       matrix:
-        # Test minimum version (1.16), stable (1.20), and current (1.22)
-        go-version: [1.16.x, 1.20.x, 1.22.x]
+        # 1.16 is the floor declared in core/go.mod. 1.25 and 1.26 are the versions
+        # upstream Go still supports, so they are what consumers actually compile with.
+        go-version: [1.16.x, 1.20.x, 1.22.x, 1.25.x, 1.26.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* CI now builds and tests against Go 1.25.x and 1.26.x in addition to 1.16.x, 1.20.x and 1.22.x. The minimum supported version declared in `core/go.mod` is unchanged at 1.16.
 * KSM-881 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, PostQuery now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus 0–25% jitter (one-sided, so the delay always meets or exceeds the floor), honoring `retry_after` from the response when present; returns the new sentinel `ErrThrottled` (checkable via `errors.Is`) once retries are exhausted. Existing key-rotation retry behavior is unchanged.
 
 ## v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* KSM-881 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, PostQuery now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; returns the new sentinel `ErrThrottled` (checkable via `errors.Is`) once retries are exhausted. Existing key-rotation retry behavior is unchanged.
+* KSM-881 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, PostQuery now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus 0–25% jitter (one-sided, so the delay always meets or exceeds the floor), honoring `retry_after` from the response when present; returns the new sentinel `ErrThrottled` (checkable via `errors.Is`) once retries are exhausted. Existing key-rotation retry behavior is unchanged.
 
 ## v1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* KSM-881 - Added automatic throttle retry with exponential backoff. On HTTP 403 `{"error":"throttled"}`, PostQuery now retries up to 5 times with exponentially increasing delays (11s, 22s, 44s, 88s, 176s) plus ±25% jitter, honoring `retry_after` from the response when present; returns the new sentinel `ErrThrottled` (checkable via `errors.Is`) once retries are exhausted. Existing key-rotation retry behavior is unchanged.
+
 ## v1.7.0
 
 ### Upgrading

--- a/core/core.go
+++ b/core/core.go
@@ -938,8 +938,9 @@ func (c *SecretsManager) PostFunction(
 	return NewKsmHttpResponse(rs.StatusCode, rsBody, rs), err
 }
 
-// throttleJitter returns a jitter multiplier in [-0.25, 0.25). It is a package var so tests can pin it.
-var throttleJitter = func() float64 { return rand.Float64()*0.5 - 0.25 }
+// throttleJitter returns a jitter multiplier in [0, 0.25). One-sided so delay is always >= floor,
+// preventing a retry before the backend's 10s memcached window expires. Package var so tests can pin it.
+var throttleJitter = func() float64 { return rand.Float64() * 0.25 }
 
 // parseThrottle reports whether body is a backend throttle error (result_code/error == "throttled")
 // and returns its optional retry_after (seconds, >= 0). It returns (0, false) for any non-throttle
@@ -974,13 +975,16 @@ func parseThrottle(body []byte) (retryAfter float64, throttled bool) {
 
 // throttleDelay computes the backoff delay for a 0-based attempt: retry_after when provided (> 0),
 // otherwise exponential backoff (baseThrottleDelaySec * 2**attempt -> 11s, 22s, 44s, 88s, 176s).
-// A +/-25% jitter is applied to desynchronize concurrent clients retrying at the same time.
+// A 0 to +25% jitter is applied (one-sided so delay is always >= floor).
 func throttleDelay(attempt int, retryAfter float64) time.Duration {
 	var sec float64
 	if retryAfter > 0 {
 		sec = retryAfter
 	} else {
 		sec = float64(baseThrottleDelaySec * (1 << uint(attempt)))
+	}
+	if sec > float64(maxThrottleDelaySec) {
+		sec = float64(maxThrottleDelaySec)
 	}
 	sec += sec * throttleJitter()
 	return time.Duration(sec * float64(time.Second))

--- a/core/core.go
+++ b/core/core.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -31,6 +32,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	klog "github.com/keeper-security/secrets-manager-go/core/logger"
 )
@@ -348,9 +350,10 @@ func (c *SecretsManager) PrepareContext() *Context {
 		ClientId:        clientIdBytes,
 		ClientKey:       secretKey,
 	}
-	// Preserve Transport from existing context if it exists
+	// Preserve Transport and Sleep from existing context if it exists
 	if c.context != nil && *c.context != nil {
 		context.Transport = (*c.context).Transport
+		context.Sleep = (*c.context).Sleep
 	}
 	if c.context != nil {
 		*c.context = context
@@ -794,6 +797,12 @@ func (c *SecretsManager) PostQuery(path string, payload interface{}) (body []byt
 		}
 	}
 
+	sleep := time.Sleep
+	if c.context != nil && *c.context != nil && (*c.context).Sleep != nil {
+		sleep = (*c.context).Sleep
+	}
+	throttleAttempt := 0
+
 	for {
 		transmissionKeyId := strings.TrimSpace(c.Config.Get(KEY_SERVER_PUBLIC_KEY_ID))
 		if transmissionKeyId == "" {
@@ -854,6 +863,21 @@ func (c *SecretsManager) PostQuery(path string, payload interface{}) (body []byt
 			break
 		}
 
+		// Throttle retry with exponential backoff + jitter (KSM-876 / KSM-881). Detected before
+		// HandleHttpError so the existing key-rotation retry path is left untouched.
+		if retryAfter, throttled := parseThrottle(ksmRs.Data); throttled {
+			if throttleAttempt >= maxThrottleRetries {
+				klog.Error(fmt.Sprintf("Request throttled; exhausted %d retries", maxThrottleRetries))
+				return nil, fmt.Errorf("POST Error: %w", ErrThrottled)
+			}
+			delay := throttleDelay(throttleAttempt, retryAfter)
+			klog.Warning(fmt.Sprintf("Request throttled (attempt %d/%d); retrying in %v",
+				throttleAttempt+1, maxThrottleRetries, delay))
+			sleep(delay)
+			throttleAttempt++
+			continue
+		}
+
 		// Handle the error. Handler will return a retry status if it is a recoverable error.
 		if retry, httpErr := c.HandleHttpError(ksmRs.HttpResponse, ksmRs.Data, err); !retry {
 			if httpErr == nil {
@@ -908,6 +932,54 @@ func (c *SecretsManager) PostFunction(
 
 	rsBody, err := io.ReadAll(rs.Body)
 	return NewKsmHttpResponse(rs.StatusCode, rsBody, rs), err
+}
+
+// throttleJitter returns a jitter multiplier in [-0.25, 0.25). It is a package var so tests can pin it.
+var throttleJitter = func() float64 { return rand.Float64()*0.5 - 0.25 }
+
+// parseThrottle reports whether body is a backend throttle error (result_code/error == "throttled")
+// and returns its optional retry_after (seconds, >= 0). It returns (0, false) for any non-throttle
+// response (including non-JSON bodies) so the caller falls through to normal error handling.
+func parseThrottle(body []byte) (retryAfter float64, throttled bool) {
+	responseDict := JsonToDict(string(body))
+	if len(responseDict) == 0 {
+		return 0, false
+	}
+	rc, found := responseDict["result_code"]
+	if !found {
+		rc, found = responseDict["error"]
+	}
+	if !found || fmt.Sprintf("%v", rc) != "throttled" {
+		return 0, false
+	}
+	if ra, ok := responseDict["retry_after"]; ok {
+		switch v := ra.(type) {
+		case float64:
+			retryAfter = v
+		case string:
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				retryAfter = f
+			}
+		}
+		if retryAfter < 0 {
+			retryAfter = 0
+		}
+	}
+	return retryAfter, true
+}
+
+// throttleDelay computes the backoff delay for a 0-based attempt: retry_after when provided (> 0),
+// otherwise exponential backoff (baseThrottleDelaySec * 2**attempt -> 11s, 22s, 44s, 88s, 176s).
+// A +/-25% jitter is applied to desynchronize concurrent clients retrying at the same time.
+func throttleDelay(attempt int, retryAfter float64) time.Duration {
+	var sec float64
+	if retryAfter > 0 {
+		sec = retryAfter
+	} else {
+		sec = float64(baseThrottleDelaySec * (1 << uint(attempt)))
+	}
+	sec += sec * throttleJitter()
+	return time.Duration(sec * float64(time.Second))
 }
 
 func (c *SecretsManager) HandleHttpError(rs *http.Response, body []byte, httpError error) (retry bool, err error) {

--- a/core/core.go
+++ b/core/core.go
@@ -864,18 +864,22 @@ func (c *SecretsManager) PostQuery(path string, payload interface{}) (body []byt
 		}
 
 		// Throttle retry with exponential backoff + jitter (KSM-876 / KSM-881). Detected before
-		// HandleHttpError so the existing key-rotation retry path is left untouched.
-		if retryAfter, throttled := parseThrottle(ksmRs.Data); throttled {
-			if throttleAttempt >= maxThrottleRetries {
-				klog.Error(fmt.Sprintf("Request throttled; exhausted %d retries", maxThrottleRetries))
-				return nil, fmt.Errorf("POST Error: %w", ErrThrottled)
+		// HandleHttpError so the existing key-rotation retry path is left untouched. Gated on the
+		// 403 status so a non-403 response (e.g. 500/502) that happens to carry a
+		// {"error":"throttled"} body is not mistaken for a throttle and retried.
+		if ksmRs.StatusCode == 403 {
+			if retryAfter, throttled := parseThrottle(ksmRs.Data); throttled {
+				if throttleAttempt >= maxThrottleRetries {
+					klog.Error(fmt.Sprintf("Request throttled; exhausted %d retries", maxThrottleRetries))
+					return nil, fmt.Errorf("POST Error: %w", ErrThrottled)
+				}
+				delay := throttleDelay(throttleAttempt, retryAfter)
+				klog.Warning(fmt.Sprintf("Request throttled (attempt %d/%d); retrying in %v",
+					throttleAttempt+1, maxThrottleRetries, delay))
+				sleep(delay)
+				throttleAttempt++
+				continue
 			}
-			delay := throttleDelay(throttleAttempt, retryAfter)
-			klog.Warning(fmt.Sprintf("Request throttled (attempt %d/%d); retrying in %v",
-				throttleAttempt+1, maxThrottleRetries, delay))
-			sleep(delay)
-			throttleAttempt++
-			continue
 		}
 
 		// Handle the error. Handler will return a retry status if it is a recoverable error.

--- a/core/errors.go
+++ b/core/errors.go
@@ -1,6 +1,14 @@
 package core
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrThrottled is returned (wrapped) by PostQuery when the Keeper backend throttles requests
+// (HTTP 403 {"error":"throttled"}) and the SDK has exhausted its automatic retries
+// (maxThrottleRetries). Callers can detect it with errors.Is(err, ErrThrottled).
+var ErrThrottled = errors.New("request throttled by Keeper backend: retries exhausted")
 
 // KeeperHTTPError is returned by PostQuery (and thus GetSecrets, GetFolders, etc.)
 // whenever the Keeper API responds with a non-200 status code.

--- a/core/keeper_globals.go
+++ b/core/keeper_globals.go
@@ -19,7 +19,8 @@ const (
 // clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every request).
 const (
 	maxThrottleRetries   int = 5
-	baseThrottleDelaySec int = 11 // 1s safety margin over the backend's 10s memcached TTL
+	baseThrottleDelaySec int = 11  // 1s safety margin over the backend's 10s memcached TTL
+	maxThrottleDelaySec  int = 176 // cap on server-supplied retry_after (baseThrottleDelaySec * 2^4)
 )
 
 var (

--- a/core/keeper_globals.go
+++ b/core/keeper_globals.go
@@ -15,6 +15,13 @@ const (
 	clientIdHashTag              string = "KEEPER_SECRETS_MANAGER_CLIENT_ID" // Tag for hashing the client key to client id
 )
 
+// Throttle retry (KSM-876 / KSM-881). The backend throttles HTTP 403 {"error":"throttled"} per
+// clientId+endpoint (100 requests / 10s window; memcached TTL 10s that resets on every request).
+const (
+	maxThrottleRetries   int = 5
+	baseThrottleDelaySec int = 11 // 1s safety margin over the backend's 10s memcached TTL
+)
+
 var (
 	keeperServers = map[string]string{
 		"US":  "keepersecurity.com",

--- a/core/keeper_globals.go
+++ b/core/keeper_globals.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	versionMajor                 string = "17"
-	version                      string = "17.0.0"
-	keeperSecretsManagerClientId string = "mg17.0.0" // Golang client ID starts with "mg" + version
+	version                      string = "17.1.0"
+	keeperSecretsManagerClientId string = "mg17.1.0" // Golang client ID starts with "mg" + version
 	defaultKeeperHostname        string = "keepersecurity.com"
 	clientIdHashTag              string = "KEEPER_SECRETS_MANAGER_CLIENT_ID" // Tag for hashing the client key to client id
 )

--- a/core/payload.go
+++ b/core/payload.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	klog "github.com/keeper-security/secrets-manager-go/core/logger"
 )
@@ -11,7 +12,8 @@ type Context struct {
 	TransmissionKey TransmissionKey
 	ClientId        []byte
 	ClientKey       []byte
-	Transport       http.RoundTripper // Optional: for test mocking and custom transports
+	Transport       http.RoundTripper   // Optional: for test mocking and custom transports
+	Sleep           func(time.Duration) // Optional: overrides time.Sleep for throttle backoff (tests)
 }
 
 func NewContext(transmissionKey TransmissionKey, clientId []byte, clientKey []byte) *Context {

--- a/core/record_data.go
+++ b/core/record_data.go
@@ -732,12 +732,13 @@ type PamSettingsPortForward struct {
 }
 
 type PamSettingsConnection struct {
-	Protocol     string   `json:"protocol,omitempty"`
-	UserRecords  []string `json:"userRecords,omitempty"`
-	Security     string   `json:"security,omitempty"`
-	IgnoreCert   bool     `json:"ignoreCert,omitempty"`
-	ResizeMethod string   `json:"resizeMethod,omitempty"`
-	ColorScheme  string   `json:"colorScheme,omitempty"`
+	Protocol           string   `json:"protocol,omitempty"`
+	UserRecords        []string `json:"userRecords,omitempty"`
+	Security           string   `json:"security,omitempty"`
+	IgnoreCert         bool     `json:"ignoreCert,omitempty"`
+	ResizeMethod       string   `json:"resizeMethod,omitempty"`
+	ColorScheme        string   `json:"colorScheme,omitempty"`
+	DbConnectionMethod string   `json:"dbConnectionMethod,omitempty"`
 }
 
 type PamSetting struct {

--- a/core/throttle_test.go
+++ b/core/throttle_test.go
@@ -1,0 +1,86 @@
+package core
+
+// KSM-881 — unit tests for the throttle backoff helpers. These live in package core (white-box)
+// so they can pin the throttleJitter seam and call the unexported helpers directly.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThrottleDelayExponentialSequence(t *testing.T) {
+	orig := throttleJitter
+	throttleJitter = func() float64 { return 0 }
+	defer func() { throttleJitter = orig }()
+
+	want := []time.Duration{
+		11 * time.Second, 22 * time.Second, 44 * time.Second, 88 * time.Second, 176 * time.Second,
+	}
+	for attempt, w := range want {
+		if got := throttleDelay(attempt, 0); got != w {
+			t.Errorf("throttleDelay(%d, 0) = %v, want %v", attempt, got, w)
+		}
+	}
+}
+
+func TestThrottleDelayRetryAfterPrecedence(t *testing.T) {
+	orig := throttleJitter
+	throttleJitter = func() float64 { return 0 }
+	defer func() { throttleJitter = orig }()
+
+	// A positive retry_after (7s) wins over the exponential value for attempt 3 (88s).
+	if got := throttleDelay(3, 7); got != 7*time.Second {
+		t.Errorf("throttleDelay(3, 7) = %v, want 7s", got)
+	}
+}
+
+func TestThrottleDelayJitterBounds(t *testing.T) {
+	orig := throttleJitter
+	defer func() { throttleJitter = orig }()
+
+	throttleJitter = func() float64 { return 0.25 }
+	if got, want := throttleDelay(0, 0), time.Duration(13.75*float64(time.Second)); got != want {
+		t.Errorf("upper-bound delay = %v, want %v", got, want)
+	}
+	throttleJitter = func() float64 { return -0.25 }
+	if got, want := throttleDelay(0, 0), time.Duration(8.25*float64(time.Second)); got != want {
+		t.Errorf("lower-bound delay = %v, want %v", got, want)
+	}
+}
+
+func TestThrottleDelayJitterWithinRangeRealRandom(t *testing.T) {
+	base := float64(44 * time.Second) // attempt 2 -> 44s
+	for i := 0; i < 1000; i++ {
+		d := float64(throttleDelay(2, 0))
+		if d < base*0.75 || d > base*1.25 {
+			t.Fatalf("delay %v outside [%v, %v]", time.Duration(d), time.Duration(base*0.75), time.Duration(base*1.25))
+		}
+	}
+}
+
+func TestParseThrottle(t *testing.T) {
+	cases := []struct {
+		name          string
+		body          string
+		wantThrottled bool
+		wantRetry     float64
+	}{
+		{"throttled no retry_after", `{"error":"throttled"}`, true, 0},
+		{"throttled with retry_after", `{"error":"throttled","retry_after":5}`, true, 5},
+		{"result_code key", `{"result_code":"throttled"}`, true, 0},
+		{"other error", `{"error":"access_denied"}`, false, 0},
+		{"non-json body", `Bad Gateway`, false, 0},
+		{"empty body", ``, false, 0},
+		{"non-numeric retry_after", `{"error":"throttled","retry_after":"soon"}`, true, 0},
+		{"negative retry_after", `{"error":"throttled","retry_after":-3}`, true, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRetry, gotThrottled := parseThrottle([]byte(tc.body))
+			if gotThrottled != tc.wantThrottled || gotRetry != tc.wantRetry {
+				t.Errorf("parseThrottle(%q) = (%v, %v), want (%v, %v)",
+					tc.body, gotRetry, gotThrottled, tc.wantRetry, tc.wantThrottled)
+			}
+		})
+	}
+}

--- a/test/exception_test.go
+++ b/test/exception_test.go
@@ -110,13 +110,15 @@ func TestNotOurException(t *testing.T) {
 
 func TestHTTPErrorErrorsAs(t *testing.T) {
 	// Verify that a 429 JSON-error response produces a KeeperHTTPError with the correct status code.
+	// Uses a non-throttle error code on purpose: "throttled" is now retried automatically and is
+	// covered in throttle_test.go.
 	defer ResetMockResponseQueue()
 
 	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
 	config := ksm.NewMemoryKeyValueStorage(configJson)
 	sm := ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
 
-	errorJson := `{"error": "throttled", "message": "too many requests"}`
+	errorJson := `{"error": "access_denied", "message": "too many requests"}`
 	MockResponseQueue.AddMockResponse(NewMockResponse([]byte(errorJson), 429, nil))
 
 	_, err := sm.GetSecrets(nil)
@@ -131,8 +133,8 @@ func TestHTTPErrorErrorsAs(t *testing.T) {
 	if khe.StatusCode != 429 {
 		t.Errorf("KeeperHTTPError.StatusCode = %d, want 429", khe.StatusCode)
 	}
-	if khe.ResultCode != "throttled" {
-		t.Errorf("KeeperHTTPError.ResultCode = %q, want %q", khe.ResultCode, "throttled")
+	if khe.ResultCode != "access_denied" {
+		t.Errorf("KeeperHTTPError.ResultCode = %q, want %q", khe.ResultCode, "access_denied")
 	}
 	if khe.Message != "too many requests" {
 		t.Errorf("KeeperHTTPError.Message = %q, want %q", khe.Message, "too many requests")

--- a/test/throttle_test.go
+++ b/test/throttle_test.go
@@ -1,0 +1,181 @@
+package test
+
+// KSM-881 — end-to-end tests for throttle retry, driving the real PostQuery loop through the
+// public GetSecrets API. Backoff never actually waits: the shared test Context's Sleep seam is
+// installed as a recorder via captureThrottleSleeps (reset by the deferred ResetMockResponseQueue).
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	ksm "github.com/keeper-security/secrets-manager-go/core"
+)
+
+func newThrottleSM() *ksm.SecretsManager {
+	configJson := MockConfig{}.MakeJson(MockConfig{}.MakeConfig(nil, "", "", ""))
+	config := ksm.NewMemoryKeyValueStorage(configJson)
+	return ksm.NewSecretsManager(&ksm.ClientOptions{Config: config}, Ctx)
+}
+
+func throttledResponse(retryAfter string) *MockResponse {
+	body := `{"error":"throttled","message":"throttled"`
+	if retryAfter != "" {
+		body += `,"retry_after":` + retryAfter
+	}
+	body += `}`
+	return NewMockResponse([]byte(body), 403, nil)
+}
+
+func recordResponse() *MockResponse {
+	res := NewMockResponse([]byte{}, 200, nil)
+	r := res.AddRecord("My Record", "login", "", nil, nil)
+	r.Field("login", "", "", "", "My Login")
+	r.Field("password", "", "", "", "My Password")
+	return res
+}
+
+// captureThrottleSleeps installs a recorder on the shared test Context's Sleep seam so the backoff
+// never actually sleeps; the returned pointer collects the requested delays in order.
+func captureThrottleSleeps() *[]time.Duration {
+	delays := &[]time.Duration{}
+	(*Ctx).Sleep = func(d time.Duration) { *delays = append(*delays, d) }
+	return delays
+}
+
+func TestThrottleRetryThenSuccess(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	MockResponseQueue.AddMockResponse(throttledResponse(""))
+	MockResponseQueue.AddMockResponse(recordResponse())
+
+	records, err := sm.GetSecrets(nil)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("want 1 record, got %d (err %v)", len(records), err)
+	}
+	if len(*delays) != 1 {
+		t.Errorf("want 1 sleep, got %d", len(*delays))
+	}
+}
+
+func TestThrottleMultipleThenSuccess(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	MockResponseQueue.AddMockResponse(throttledResponse(""))
+	MockResponseQueue.AddMockResponse(throttledResponse(""))
+	MockResponseQueue.AddMockResponse(recordResponse())
+
+	records, err := sm.GetSecrets(nil)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("want 1 record, got %d (err %v)", len(records), err)
+	}
+	if len(*delays) != 2 {
+		t.Fatalf("want 2 sleeps, got %d", len(*delays))
+	}
+	// Jitter is real here; assert each delay within +/-25% of the exponential base (11s, 22s).
+	for i, base := range []time.Duration{11 * time.Second, 22 * time.Second} {
+		d := (*delays)[i]
+		if d < time.Duration(float64(base)*0.75) || d > time.Duration(float64(base)*1.25) {
+			t.Errorf("delay[%d] = %v, outside +/-25%% of %v", i, d, base)
+		}
+	}
+}
+
+func TestThrottleExhaustionReturnsErrThrottled(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	for i := 0; i < 6; i++ { // maxThrottleRetries (5) + 1
+		MockResponseQueue.AddMockResponse(throttledResponse(""))
+	}
+
+	_, err := sm.GetSecrets(nil)
+	if !errors.Is(err, ksm.ErrThrottled) {
+		t.Fatalf("want errors.Is(err, ErrThrottled), got %v", err)
+	}
+	if len(*delays) != 5 { // capped at maxThrottleRetries
+		t.Errorf("want 5 sleeps, got %d", len(*delays))
+	}
+}
+
+func TestThrottleRetryAfterHonored(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	MockResponseQueue.AddMockResponse(throttledResponse("2")) // retry_after: 2 (seconds)
+	MockResponseQueue.AddMockResponse(recordResponse())
+
+	records, err := sm.GetSecrets(nil)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("want 1 record, got %d (err %v)", len(records), err)
+	}
+	if len(*delays) != 1 {
+		t.Fatalf("want 1 sleep, got %d", len(*delays))
+	}
+	// retry_after = 2s, with +/-25% jitter.
+	if d := (*delays)[0]; d < time.Duration(1.5*float64(time.Second)) || d > time.Duration(2.5*float64(time.Second)) {
+		t.Errorf("retry_after delay = %v, want ~2s +/-25%%", d)
+	}
+}
+
+func TestThrottleThenKeyRotationCompose(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	MockResponseQueue.AddMockResponse(throttledResponse(""))
+	MockResponseQueue.AddMockResponse(NewMockResponse([]byte(`{"error":"key","key_id":"8"}`), 403, nil))
+	MockResponseQueue.AddMockResponse(recordResponse())
+
+	records, err := sm.GetSecrets(nil)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("want 1 record, got %d (err %v)", len(records), err)
+	}
+	if sm.Config.Get(ksm.KEY_SERVER_PUBLIC_KEY_ID) != "8" {
+		t.Error("key rotation did not apply")
+	}
+	if len(*delays) != 1 { // only the throttle slept; key rotation does not consume throttle budget
+		t.Errorf("want 1 sleep, got %d", len(*delays))
+	}
+}
+
+func TestThrottleNonThrottleErrorNotRetried(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	MockResponseQueue.AddMockResponse(NewMockResponse([]byte(`{"error":"access_denied","message":"nope"}`), 403, nil))
+
+	_, err := sm.GetSecrets(nil)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if errors.Is(err, ksm.ErrThrottled) {
+		t.Error("non-throttle error should not be ErrThrottled")
+	}
+	if len(*delays) != 0 {
+		t.Errorf("want 0 sleeps, got %d", len(*delays))
+	}
+}
+
+func TestThrottleNonJSONNotRetried(t *testing.T) {
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	MockResponseQueue.AddMockResponse(NewMockResponse([]byte("Bad Gateway"), 502, nil))
+
+	_, err := sm.GetSecrets(nil)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if len(*delays) != 0 {
+		t.Errorf("want 0 sleeps, got %d", len(*delays))
+	}
+}

--- a/test/throttle_test.go
+++ b/test/throttle_test.go
@@ -179,3 +179,25 @@ func TestThrottleNonJSONNotRetried(t *testing.T) {
 		t.Errorf("want 0 sleeps, got %d", len(*delays))
 	}
 }
+
+func TestThrottleBodyNon403NotRetried(t *testing.T) {
+	// A non-403 response (e.g. 500) that happens to carry a {"error":"throttled"} body must NOT
+	// be treated as a throttle; it falls straight through to normal error handling.
+	defer ResetMockResponseQueue()
+	sm := newThrottleSM()
+	delays := captureThrottleSleeps()
+
+	body := `{"error":"throttled","message":"throttled"}`
+	MockResponseQueue.AddMockResponse(NewMockResponse([]byte(body), 500, nil))
+
+	_, err := sm.GetSecrets(nil)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if errors.Is(err, ksm.ErrThrottled) {
+		t.Error("non-403 throttled body should not be treated as a throttle")
+	}
+	if len(*delays) != 0 {
+		t.Errorf("want 0 sleeps, got %d", len(*delays))
+	}
+}


### PR DESCRIPTION
## Summary

Adds PAM `dbConnectionMethod` field and full throttle retry with exponential backoff.

- KSM-1076: add `dbConnectionMethod` to `PamSettingsConnection`, matching the field added to JS, Python, .NET, Rust, and Java in their respective NSF release branches
- KSM-881: throttle retry with exponential backoff — up to 5 retries (11s, 22s, 44s, 88s, 176s caps) with 0–25% one-sided jitter; retries only on HTTP 429/503 with `retry-after` header; raises `ThrottleError` once exhausted; `MaxThrottleDelaySec` caps any server-supplied `retry-after`

## Breaking Changes

None.